### PR TITLE
Improved single character permutation in stringPermutations

### DIFF
--- a/src/Algorithm/Various/Permutation.php
+++ b/src/Algorithm/Various/Permutation.php
@@ -51,7 +51,7 @@ class Permutation {
         if (0 === $strLen) {
             return $result;
         }
-        if (1 === $string) {
+        if (1 === $strLen) {
             $result[] = $string;
             return $result;
         }

--- a/tests/Various/PermutationTest.php
+++ b/tests/Various/PermutationTest.php
@@ -41,6 +41,9 @@ class PermutationTest extends TestCase {
         $this->assertTrue(\in_array("cba", $permutations));
         $this->assertTrue(\in_array("bac", $permutations));
         $this->assertTrue(\in_array("acb", $permutations));
+
+        $permutations = $permutation->stringPermutations("a");
+        $this->assertTrue(1 === \count($permutations));
     }
 
     public function testNumberPermutation() {
@@ -50,6 +53,9 @@ class PermutationTest extends TestCase {
 
         $permutations = $permutation->numberPermutations(1234);
         $this->assertTrue(\in_array(4321, $permutations));
+
+        $permutations = $permutation->numberPermutations(1);
+        $this->assertTrue(1 === \count($permutations));
     }
 
 }


### PR DESCRIPTION
Strings with a single permutation would call `Permutation.permute` due to wrong comparison in `Permutation.stringPermutations`.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to a wrong comparison in [Permutation.php#L54](https://github.com/doganoo/PHPAlgorithms/blob/master/src/Algorithm/Various/Permutation.php#L54), a call to private function `private` was issued when single character permutations were required.

This PR fixes the comparison, which is of course just a minor improvement on an edge case.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #9 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes a minor edge case, adding negligible performance gain.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added additional test cases.