### PR TITLE
Migrate from plural to singular names in namespaces

### DIFF
--- a/src/Algorithm/Search/BidirectionalSearch.php
+++ b/src/Algorithm/Search/BidirectionalSearch.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -28,7 +30,7 @@ namespace doganoo\PHPAlgorithms\Algorithm\Search;
 
 
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\Node;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 
 /**
  * TODO implement AbstractGraphSearch

--- a/src/Algorithm/Sorting/TopologicalSort.php
+++ b/src/Algorithm/Sorting/TopologicalSort.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +33,7 @@ use doganoo\PHPAlgorithms\Common\Exception\InvalidGraphTypeException;
 use doganoo\PHPAlgorithms\Common\Interfaces\IGraphSortable;
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\DirectedGraph;
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\Node;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use doganoo\PHPAlgorithms\Datastructure\Stackqueue\Stack;
 
 /**

--- a/src/Algorithm/Various/Converter.php
+++ b/src/Algorithm/Various/Converter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -26,7 +28,7 @@ declare(strict_types=1);
 
 namespace doganoo\PHPAlgorithms\Algorithm\Various;
 
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use doganoo\PHPAlgorithms\Datastructure\Table\HashTable;
 
 /**

--- a/src/Algorithm/Various/Misc.php
+++ b/src/Algorithm/Various/Misc.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -28,7 +30,7 @@ namespace doganoo\PHPAlgorithms\Algorithm\Various;
 
 use doganoo\PHPAlgorithms\Common\Exception\IndexOutOfBoundsException;
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 
 
 /**

--- a/src/Common/Abstracts/AbstractGraph.php
+++ b/src/Common/Abstracts/AbstractGraph.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -34,7 +36,7 @@ use doganoo\PHPAlgorithms\common\Exception\UnsupportedKeyTypeException;
 use doganoo\PHPAlgorithms\Common\Interfaces\IComparable;
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\Node;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use doganoo\PHPAlgorithms\Datastructure\Stackqueue\Queue;
 use doganoo\PHPAlgorithms\Datastructure\Table\HashTable;
 use JsonSerializable;

--- a/src/Common/Abstracts/AbstractGraphSearch.php
+++ b/src/Common/Abstracts/AbstractGraphSearch.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +29,7 @@ declare(strict_types=1);
 namespace doganoo\PHPAlgorithms\Common\Abstracts;
 
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\Node;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use function is_callable;
 
 /**

--- a/src/Datastructure/Graph/Graph/DirectedGraph.php
+++ b/src/Datastructure/Graph/Graph/DirectedGraph.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +29,7 @@ declare(strict_types=1);
 namespace doganoo\PHPAlgorithms\Datastructure\Graph\Graph;
 
 use doganoo\PHPAlgorithms\Common\Abstracts\AbstractGraph;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 
 /**
  * Class Graph

--- a/src/Datastructure/Graph/Graph/Node.php
+++ b/src/Datastructure/Graph/Graph/Node.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +30,7 @@ namespace doganoo\PHPAlgorithms\Datastructure\Graph\Graph;
 
 use doganoo\PHPAlgorithms\Common\Interfaces\INode;
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 
 /**
  * Class Node

--- a/src/Datastructure/Graph/Tree/Tree/Node.php
+++ b/src/Datastructure/Graph/Tree/Tree/Node.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +30,7 @@ namespace doganoo\PHPAlgorithms\Datastructure\Graph\Tree\Tree;
 
 use doganoo\PHPAlgorithms\Common\Interfaces\INode;
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 
 /**
  * Class Node

--- a/src/Datastructure/Lists/ArrayList/ArrayList.php
+++ b/src/Datastructure/Lists/ArrayList/ArrayList.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists;
+namespace doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList;
 
 use ArrayIterator;
 use doganoo\PHPAlgorithms\Algorithm\Sorting\TimSort;
@@ -56,7 +58,7 @@ use const ARRAY_FILTER_USE_BOTH;
  *
  * see here: https://gist.github.com/wwsun/71ebbaded68930884746
  *
- * @package doganoo\PHPAlgorithms\Lists\ArrayLists
+ * @package doganoo\PHPAlgorithms\Lists\ArrayList
  */
 class ArrayList implements IteratorAggregate, JsonSerializable, IComparable {
 

--- a/src/Datastructure/Lists/ArrayList/StringBuilder.php
+++ b/src/Datastructure/Lists/ArrayList/StringBuilder.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists;
+namespace doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList;
 
 use doganoo\PHPAlgorithms\Common\Exception\IndexOutOfBoundsException;
 use doganoo\PHPAlgorithms\Datastructure\Stackqueue\Queue;
@@ -36,7 +38,7 @@ use function strlen;
 /**
  * Class StringBuilder
  *
- * @package doganoo\PHPAlgorithms\Lists\ArrayLists
+ * @package doganoo\PHPAlgorithms\Lists\ArrayList
  */
 class StringBuilder {
     /** @var ArrayList $arrayList */

--- a/src/Datastructure/Lists/LinkedList/DoublyLinkedList.php
+++ b/src/Datastructure/Lists/LinkedList/DoublyLinkedList.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists;
+namespace doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList;
 
 use doganoo\PHPAlgorithms\Common\Abstracts\AbstractLinkedList;
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
@@ -32,7 +34,7 @@ use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 /**
  * Class DoublyLinkedList
  *
- * @package doganoo\PHPAlgorithms\LinkedLists
+ * @package doganoo\PHPAlgorithms\LinkedList
  */
 class DoublyLinkedList extends AbstractLinkedList {
 

--- a/src/Datastructure/Lists/LinkedList/SinglyLinkedList.php
+++ b/src/Datastructure/Lists/LinkedList/SinglyLinkedList.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists;
+namespace doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList;
 
 use doganoo\PHPAlgorithms\Common\Abstracts\AbstractLinkedList;
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
@@ -32,7 +34,7 @@ use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 /**
  * Class SinglyLinkedList
  *
- * @package doganoo\PHPAlgorithms\LinkedLists
+ * @package doganoo\PHPAlgorithms\LinkedList
  */
 class SinglyLinkedList extends AbstractLinkedList {
 

--- a/src/Datastructure/Map/Map.php
+++ b/src/Datastructure/Map/Map.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Maps;
+namespace doganoo\PHPAlgorithms\Datastructure\Map;
 
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
 use function array_fill;
@@ -35,7 +37,7 @@ use const ARRAY_FILTER_USE_BOTH;
 /**
  * Class Map
  *
- * @package doganoo\PHPAlgorithms\Datastructure\maps
+ * @package doganoo\PHPAlgorithms\Datastructure\Map
  */
 class Map {
 

--- a/src/Datastructure/Set/HashSet.php
+++ b/src/Datastructure/Set/HashSet.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithms\Datastructure\Sets;
+namespace doganoo\PHPAlgorithms\Datastructure\Set;
 
 use doganoo\PHPAlgorithms\Common\Abstracts\AbstractSet;
 use doganoo\PHPAlgorithms\Common\Exception\InvalidKeyTypeException;
@@ -37,7 +39,7 @@ use function is_iterable;
 /**
  * Class HashSet
  *
- * @package doganoo\PHPAlgorithms\Datastructure\Sets
+ * @package doganoo\PHPAlgorithms\Datastructure\Set
  */
 class HashSet extends AbstractSet implements ISet {
 

--- a/src/Datastructure/Stackqueue/StackSet.php
+++ b/src/Datastructure/Stackqueue/StackSet.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 /**
  * MIT License
  *
- * Copyright (c) 2018 Dogan Ucar
+ * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
+ *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +31,7 @@ namespace doganoo\PHPAlgorithms\Datastructure\Stackqueue;
 use doganoo\PHPAlgorithms\Common\Exception\IndexOutOfBoundsException;
 use doganoo\PHPAlgorithms\Common\Interfaces\IComparable;
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use JsonSerializable;
 
 /**

--- a/src/Datastructure/Table/HashTable.php
+++ b/src/Datastructure/Table/HashTable.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -31,7 +33,7 @@ use doganoo\PHPAlgorithms\Common\Abstracts\AbstractTable;
 use doganoo\PHPAlgorithms\Common\Exception\InvalidKeyTypeException;
 use doganoo\PHPAlgorithms\Common\Exception\UnsupportedKeyTypeException;
 use doganoo\PHPAlgorithms\Common\Util\MapUtil;
-use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists\SinglyLinkedList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList\SinglyLinkedList;
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 use JsonSerializable;
 

--- a/tests/Comparator/ComparatorTest.php
+++ b/tests/Comparator/ComparatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -28,7 +30,7 @@ namespace doganoo\PHPAlgorithmsTest\Comparator;
 
 use doganoo\PHPAlgorithms\Common\Util\Comparator;
 use doganoo\PHPAlgorithms\Datastructure\Graph\Graph\Node;
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use PHPUnit\Framework\TestCase;
 
 class ComparatorTest extends TestCase {

--- a/tests/Lists/ArrayList/ArrayListTest.php
+++ b/tests/Lists/ArrayList/ArrayListTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,9 +26,9 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Lists\ArrayLists;
+namespace doganoo\PHPAlgorithmsTest\Lists\ArrayList;
 
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\ArrayList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\ArrayList;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 

--- a/tests/Lists/ArrayList/StringBuilderTest.php
+++ b/tests/Lists/ArrayList/StringBuilderTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,9 +26,9 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Lists\ArrayLists;
+namespace doganoo\PHPAlgorithmsTest\Lists\ArrayList;
 
-use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayLists\StringBuilder;
+use doganoo\PHPAlgorithms\Datastructure\Lists\ArrayList\StringBuilder;
 use PHPUnit\Framework\TestCase;
 
 class StringBuilderTest extends TestCase {

--- a/tests/Lists/LinkedList/DoublyLinkedListTest.php
+++ b/tests/Lists/LinkedList/DoublyLinkedListTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Lists\LinkedLists;
+namespace doganoo\PHPAlgorithmsTest\Lists\LinkedList;
 
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 use doganoo\PHPAlgorithmsTest\Util\LinkedListUtil;

--- a/tests/Lists/LinkedList/SinglyLinkedListTest.php
+++ b/tests/Lists/LinkedList/SinglyLinkedListTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,9 +26,9 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Lists\LinkedLists;
+namespace doganoo\PHPAlgorithmsTest\Lists\LinkedList;
 
-use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists\SinglyLinkedList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList\SinglyLinkedList;
 use doganoo\PHPAlgorithmsTest\Util\LinkedListUtil;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Map/NodeTest.php
+++ b/tests/Map/NodeTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,7 +26,7 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Maps;
+namespace doganoo\PHPAlgorithmsTest\Map;
 
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 use PHPUnit\Framework\TestCase;

--- a/tests/Set/HashSetTest.php
+++ b/tests/Set/HashSetTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -24,11 +26,11 @@ declare(strict_types=1);
  * SOFTWARE.
  */
 
-namespace doganoo\PHPAlgorithmsTest\Sets;
+namespace doganoo\PHPAlgorithmsTest\Set;
 
 use doganoo\PHPAlgorithms\common\Exception\InvalidKeyTypeException;
 use doganoo\PHPAlgorithms\Common\Exception\UnsupportedKeyTypeException;
-use doganoo\PHPAlgorithms\Datastructure\Sets\HashSet;
+use doganoo\PHPAlgorithms\Datastructure\Set\HashSet;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Util/LinkedListUtil.php
+++ b/tests/Util/LinkedListUtil.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
  *
  * Copyright (c) 2018 Dogan Ucar, <dogan@dogan-ucar.de>
  *
+ * @author Eugene Kirillov <eug.krlv@gmail.com>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -26,8 +28,8 @@ declare(strict_types=1);
 
 namespace doganoo\PHPAlgorithmsTest\Util;
 
-use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists\DoublyLinkedList;
-use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedLists\SinglyLinkedList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList\DoublyLinkedList;
+use doganoo\PHPAlgorithms\Datastructure\Lists\LinkedList\SinglyLinkedList;
 use doganoo\PHPAlgorithms\Datastructure\Lists\Node;
 use stdClass;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Renamed following namespaces:
- `doganoo\PHPAlgorithms\Datastructure\Lists\{ArrayLists => ArrayList}\ArrayList`
- `doganoo\PHPAlgorithms\Datastructure\Lists\{ArrayLists => ArrayList}\StringBuilder`
- `doganoo\PHPAlgorithms\Datastructure\Lists\{LinkedLists => LinkedList}\DoublyLinkedList`
- `doganoo\PHPAlgorithms\Datastructure\Lists\{LinkedLists => LinkedList}\SinglyLinkedList`
- `doganoo\PHPAlgorithms\Datastructure\{Maps => Map}\HashMap`
- `doganoo\PHPAlgorithms\Datastructure\{Maps => Map}\IntegerVector`
- `doganoo\PHPAlgorithms\Datastructure\{Maps => Map}\Map`
- `doganoo\PHPAlgorithms\Datastructure\{Sets => Set}\HashSet`
- `doganoo\PHPAlgorithms\{Maps => Map}\HashMapTest`
- `doganoo\PHPAlgorithms\{Maps => Map}\NodeTest`
- `doganoo\PHPAlgorithms\{Sets => Set}\HashSetTest`

## Related Issue
#6 

## Motivation and Context
#6 

**NB!** Following namespace left in plural names:
- `doganoo\PHPAlgorithms\Datastructure\Lists`
- `doganoo\PHPAlgorithms\Common\Abstracts`
- `doganoo\PHPAlgorithms\Common\Interfaces`

These namespaces cannot be renamed to singular form, because `list`, `abstract` and `interface` are reserved words in PHP

## How Has This Been Tested?
By running PHPUnit tests
```bash
$ phpunit
PHPUnit 6.5.0 by Sebastian Bergmann and contributors.

.....S...........S............................................... 65 / 94 ( 69%)
.............................                                     94 / 94 (100%)
```
