### PR TITLE
Use $size instead of counting on each iteration in QuickSort

### DIFF
--- a/src/Algorithm/Sorting/QuickSort.php
+++ b/src/Algorithm/Sorting/QuickSort.php
@@ -4,6 +4,8 @@
  *
  * Copyright (c) 2018 Dogan Ucar
  *
+ * @author Alexey Berezuev <alexey@berezuev.ru>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -48,7 +50,7 @@ class QuickSort implements ISortable {
         $pivot = $array[0];
         $left = $right = [];
 
-        for ($i = 1; $i < count($array); $i++) {
+        for ($i = 1; $i < $size; $i++) {
             if (Comparator::lessThan($array[$i], $pivot)) {
                 $left[] = $array[$i];
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use $size instead of counting on each iteration in QuickSort

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
