### PR TITLE
unit-test to catch a TimSort issue

### DIFF
--- a/tests/Sorting/SortTest.php
+++ b/tests/Sorting/SortTest.php
@@ -111,6 +111,12 @@ class SortTest extends TestCase {
         $arr = [1];
         $result = $timSort->sort($arr);
         $this->assertTrue($result === [1]);
+
+        $expected = range(1, 42, 1);
+        $arr = $expected;
+        shuffle($arr);
+        $result = $timSort->sort($arr);
+        $this->assertTrue($result === $expected, 'unexpected result: ' . implode(', ', $result));
     }
 
     public function testQuickSort() {


### PR DESCRIPTION
## Description
This is a failing test to prove TimSort is badly implemented.

## Motivation and Context
Current implementation of TimSort works for arrays up to 32 items only.

## How Has This Been Tested?
I've just generated a list of 42 numbers, from 1 to 42, shuffled it and sorted it with TimSort. The result should equal the initial sorted array.

